### PR TITLE
Added support for building with `prof`.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,11 @@
 common:prof --//settings/flags:enable_xmalloc
 common:prof --//settings/flags:enable_prof
 common:prof --//settings/flags:enable_prof_libunwind
+
+common:prof-libgcc --//settings/flags:enable_xmalloc
+common:prof-libgcc --//settings/flags:enable_prof
+common:prof-libgcc --//settings/flags:enable_prof_libgcc
+
+common:prof-gcc --//settings/flags:enable_xmalloc
+common:prof-gcc --//settings/flags:enable_prof
+common:prof-gcc --//settings/flags:enable_prof_gcc

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
-common:prof --//settings/flags:enable_xmalloc
-common:prof --//settings/flags:enable_prof
-common:prof --//settings/flags:enable_prof_libunwind
+common:prof-libunwind --//settings/flags:enable_xmalloc
+common:prof-libunwind --//settings/flags:enable_prof
+common:prof-libunwind --//settings/flags:enable_prof_libunwind
 
 common:prof-libgcc --//settings/flags:enable_xmalloc
 common:prof-libgcc --//settings/flags:enable_prof

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+common:prof --//settings/flags:enable_xmalloc
+common:prof --//settings/flags:enable_prof
+common:prof --//settings/flags:enable_prof_libunwind

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -130,7 +130,10 @@ cc_library(
     }),
     tags = ["manual"],
     visibility = ["//:__subpackages__"],
-    deps = ["//include/jemalloc/internal"],
+    deps = ["//include/jemalloc/internal"] + select({
+        "//settings/flags:prof_libunwind": ["@libunwind"],
+        "//conditions:default": [],
+    }),
 )
 
 transition_default_constraints(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,13 +1,13 @@
 module(
     name = "jemalloc",
     version = "5.3.0-bcr.alpha.2",
-    bazel_compatibility = [">=7.2.1"],
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
     compatibility_level = 5,
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "libunwind", version = "1.8.1")
-bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_license", version = "1.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "libunwind", version = "1.8.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_license", version = "1.0.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -44,8 +44,11 @@
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/libunwind/1.8.1/MODULE.bazel": "d9b947b15135786aed51671c22872a93e2637c74caa20e94f2061fd3b1efd6c3",
+    "https://bcr.bazel.build/modules/libunwind/1.8.1/source.json": "2b4e58e2fa6ed7204862ab1a4e5978e4107340884c3217596ff7910b8dfae919",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
-    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
@@ -71,11 +74,12 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.17/source.json": "4db99b3f55c90ab28d14552aa0632533e3e8e5e9aea0f5c24ac0014282c2a7c5",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
@@ -131,9 +135,12 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
     "https://bcr.bazel.build/modules/stardoc/0.7.1/source.json": "b6500ffcd7b48cd72c29bb67bcac781e12701cc0d6d55d266a652583cfcdab01",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/xz/5.4.5.bcr.5/MODULE.bazel": "b93d7035ac14c900dfdf7624e42cfcbfc34415aa8d3c83a6f225867c48d28dad",
+    "https://bcr.bazel.build/modules/xz/5.4.5.bcr.5/source.json": "30c4e5c856087a60d92e2522eafd316c0661671f4478ca94c6b7bd877010210a",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
@@ -465,22 +472,6 @@
             "bazel_tools"
           ]
         ]
-      }
-    },
-    "@@platforms//host:extension.bzl%host_platform": {
-      "general": {
-        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "SeQiIN/f8/Qt9vYQk7qcXp4I4wJeEC0RnQDiaaJ4tb8=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "host_platform": {
-            "repoRuleId": "@@platforms//host:extension.bzl%host_platform_repo",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": []
       }
     },
     "@@pybind11_bazel+//:python_configure.bzl%extension": {

--- a/include/jemalloc/internal/BUILD.bazel
+++ b/include/jemalloc/internal/BUILD.bazel
@@ -322,9 +322,10 @@ configure_header(
         define_macro_if("JEMALLOC_STATS", "//settings/flags:stats") |
         # JEMALLOC_EXPERIMENTAL_SMALLOCX_API: Configurable flag
         define_macro_if("JEMALLOC_EXPERIMENTAL_SMALLOCX_API", "//settings/flags:experimental_smallocx_api") |
-        # JEMALLOC_PROF_LIBGCC and JEMALLOC_PROF_GCC: Not currently supported
-        undefine_macro("JEMALLOC_PROF_LIBGCC") |
-        undefine_macro("JEMALLOC_PROF_GCC") |
+        # JEMALLOC_PROF_LIBGCC: Configurable flag
+        define_macro_if("JEMALLOC_PROF_LIBGCC", "//settings/flags:prof_libgcc") |
+        # JEMALLOC_PROF_GCC: Configurable flag
+        define_macro_if("JEMALLOC_PROF_GCC", "//settings/flags:prof_gcc") |
         # JEMALLOC_PROF_LIBUNWIND: Configurable flag
         define_macro_if("JEMALLOC_PROF_LIBUNWIND", "//settings/flags:prof_libunwind") |
         # JEMALLOC_PROF: Configurable flag

--- a/include/jemalloc/internal/BUILD.bazel
+++ b/include/jemalloc/internal/BUILD.bazel
@@ -322,11 +322,13 @@ configure_header(
         define_macro_if("JEMALLOC_STATS", "//settings/flags:stats") |
         # JEMALLOC_EXPERIMENTAL_SMALLOCX_API: Configurable flag
         define_macro_if("JEMALLOC_EXPERIMENTAL_SMALLOCX_API", "//settings/flags:experimental_smallocx_api") |
-        # JEMALLOC_PROF and related: Assume off by default, not critical for core functionality
-        undefine_macro("JEMALLOC_PROF_LIBUNWIND") |
+        # JEMALLOC_PROF_LIBGCC and JEMALLOC_PROF_GCC: Not currently supported
         undefine_macro("JEMALLOC_PROF_LIBGCC") |
         undefine_macro("JEMALLOC_PROF_GCC") |
-        undefine_macro("JEMALLOC_PROF") |
+        # JEMALLOC_PROF_LIBUNWIND: Configurable flag
+        define_macro_if("JEMALLOC_PROF_LIBUNWIND", "//settings/flags:prof_libunwind") |
+        # JEMALLOC_PROF: Configurable flag
+        define_macro_if("JEMALLOC_PROF", "//settings/flags:prof") |
         # JEMALLOC_DSS: sbrk(2) deprecated on macOS, disable
         define_macro_if_any(
             "JEMALLOC_DSS",

--- a/settings/BUILD.bazel
+++ b/settings/BUILD.bazel
@@ -1,10 +1,11 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_setting", "string_setting")
 
+package(default_visibility = ["//:__subpackages__"])
+
 # JEMALLOC_JET - Explicitly used for testing
 bool_setting(
     name = "enable_jet",
     build_setting_default = False,
-    visibility = ["//:__subpackages__"],
 )
 
 config_setting(
@@ -17,7 +18,6 @@ config_setting(
 bool_setting(
     name = "enable_no_private_namespace",
     build_setting_default = False,
-    visibility = ["//:__subpackages__"],
 )
 
 config_setting(
@@ -35,7 +35,6 @@ string_setting(
         "integration",
         "integration_cpp",
     ],
-    visibility = ["//:__subpackages__"],
 )
 
 # JEMALLOC_UNIT_TEST

--- a/settings/flags/BUILD.bazel
+++ b/settings/flags/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag", "string_flag", "string_setting")
 
+package(default_visibility = ["//:__subpackages__"])
+
 ### Bazel-ification of optional flags accepted by ./configure ###
 
 # JEMALLOC_CACHE_OBLIVIOUS
@@ -135,7 +137,6 @@ string_setting(
     name = "jemalloc_cprefix",
     build_setting_default = "",
     make_variable = "JEMALLOC_CPREFIX",
-    visibility = ["//:__subpackages__"],
 )
 
 # LG_QUANTUM Base 2 log of minimum allocation alignment (--with-lg-quantum), -1 is undefined for resolution internal

--- a/settings/flags/BUILD.bazel
+++ b/settings/flags/BUILD.bazel
@@ -180,3 +180,27 @@ config_setting(
     name = "zone_allocator",
     flag_values = {":enable_zone_allocator": "yes"},
 )
+
+# JEMALLOC_PROF
+bool_flag(
+    name = "enable_prof",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "prof",
+    flag_values = {":enable_prof": "True"},
+)
+
+# JEMALLOC_PROF_LIBUNWIND
+bool_flag(
+    name = "enable_prof_libunwind",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "prof_libunwind",
+    flag_values = {":enable_prof_libunwind": "True"},
+)

--- a/settings/flags/BUILD.bazel
+++ b/settings/flags/BUILD.bazel
@@ -204,3 +204,27 @@ config_setting(
     name = "prof_libunwind",
     flag_values = {":enable_prof_libunwind": "True"},
 )
+
+# JEMALLOC_PROF_LIBGCC
+bool_flag(
+    name = "enable_prof_libgcc",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "prof_libgcc",
+    flag_values = {":enable_prof_libgcc": "True"},
+)
+
+# JEMALLOC_PROF_GCC
+bool_flag(
+    name = "enable_prof_gcc",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "prof_gcc",
+    flag_values = {":enable_prof_gcc": "True"},
+)

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -71,6 +71,8 @@ cc_library(
         "include/test/test.h",
         "include/test/thd.h",
         "include/test/timer.h",
+        "//test/unit:arena_reset.c",  # included by arena_reset_prof.c
+        "//test/unit:batch_alloc.c",  # included by batch_alloc_prof.c
     ],
     copts = COPTS,
     includes = ["include"],

--- a/test/unit/BUILD.bazel
+++ b/test/unit/BUILD.bazel
@@ -2,21 +2,37 @@ load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//tools:cc.bzl", "COPTS")
 load("//tools:transition.bzl", "PLATFORM", "transition_default_constraints")
 
-# TODO: Handle conf when enable_prof = True
-#{ "src": "batch_alloc_prof.c" },
-#{ "src": "arena_reset_prof.c" },
+exports_files(
+    [
+        "arena_reset.c",
+        "batch_alloc.c",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
 UNIT_TESTS = [
     {"src": "a0.c"},
     {
         "src": "arena_decay.c",
         "conf": "dirty_decay_ms:1000,muzzy_decay_ms:1000,tcache_max:1024",
     },
+    {
+        "src": "arena_reset_prof.c",
+        "conf": "prof:true,lg_prof_sample:0",
+    },
     {"src": "arena_reset.c"},
     {"src": "atomic.c"},
     {"src": "background_thread.c"},
     {"src": "background_thread_enable.c"},
     {"src": "base.c"},
-    {"src": "batch_alloc.c"},
+    {
+        "src": "batch_alloc_prof.c",
+        "conf": "prof:true,lg_prof_sample:14",
+    },
+    {
+        "src": "batch_alloc.c",
+        "conf": "tcache_gc_incr_bytes:2147483648",
+    },
     {
         "src": "binshard.c",
         "conf": "narenas:1,bin_shards:1-160:16|129-512:4|256-256:8",
@@ -50,7 +66,10 @@ UNIT_TESTS = [
     },
     {"src": "hpdata.c"},
     {"src": "huge.c"},
-    {"src": "inspect.c"},
+    {
+        "src": "inspect.c",
+        "prof_conf": "prof:false",
+    },
     {
         "src": "junk.c",
         "conf": "abort:false,zero:false,junk:true",
@@ -67,7 +86,10 @@ UNIT_TESTS = [
     },
     {"src": "log.c"},
     {"src": "mallctl.c"},
-    {"src": "malloc_conf_2.c"},
+    {
+        "src": "malloc_conf_2.c",
+        "conf": "dirty_decay_ms:500",
+    },
     {"src": "malloc_io.c"},
     {"src": "math.c"},
     {"src": "mpsc_queue.c"},
@@ -76,24 +98,67 @@ UNIT_TESTS = [
     {"src": "nstime.c"},
     {"src": "oversize_threshold.c"},
     {"src": "pa.c"},
-    {"src": "pack.c"},
+    {
+        "src": "pack.c",
+        "conf": "dirty_decay_ms:0,muzzy_decay_ms:0",
+    },
     {"src": "pages.c"},
     {"src": "peak.c"},
     {"src": "ph.c"},
     {"src": "prng.c"},
-    {"src": "prof_accum.c"},
-    {"src": "prof_active.c"},
-    {"src": "prof_gdump.c"},
-    {"src": "prof_hook.c"},
-    {"src": "prof_idump.c"},
-    {"src": "prof_log.c"},
-    {"src": "prof_mdump.c"},
-    {"src": "prof_recent.c"},
-    {"src": "prof_reset.c"},
-    {"src": "prof_stats.c"},
-    {"src": "prof_tctx.c"},
-    {"src": "prof_thread_name.c"},
-    {"src": "prof_sys_thread_name.c"},
+    {
+        "src": "prof_accum.c",
+        "prof_conf": "prof:true,prof_accum:true,prof_active:false,lg_prof_sample:0",
+    },
+    {
+        "src": "prof_active.c",
+        "prof_conf": "prof:true,prof_active:true,prof_thread_active_init:false,lg_prof_sample:0",
+    },
+    {
+        "src": "prof_gdump.c",
+        "prof_conf": "prof:true,prof_active:false,prof_gdump:true",
+    },
+    {
+        "src": "prof_hook.c",
+        "prof_conf": "prof:true,prof_active:true,lg_prof_sample:0",
+    },
+    {
+        "src": "prof_idump.c",
+        "conf": "tcache:false",
+        "prof_conf": ",prof:true,prof_accum:true,prof_active:false,lg_prof_sample:0,lg_prof_interval:0",
+    },
+    {
+        "src": "prof_log.c",
+        "prof_conf": "prof:true,prof_active:true,lg_prof_sample:0",
+    },
+    {
+        "src": "prof_mdump.c",
+        "prof_conf": "prof:true,lg_prof_sample:0",
+    },
+    {
+        "src": "prof_recent.c",
+        "prof_conf": "prof:true,prof_active:true,lg_prof_sample:0,prof_recent_alloc_max:3",
+    },
+    {
+        "src": "prof_reset.c",
+        "prof_conf": "prof:true,prof_active:false,lg_prof_sample:0,prof_recent_alloc_max:0",
+    },
+    {
+        "src": "prof_stats.c",
+        "prof_conf": "prof:true,prof_active:true,lg_prof_sample:0,prof_stats:true",
+    },
+    {
+        "src": "prof_tctx.c",
+        "prof_conf": "prof:true,prof_active:true,lg_prof_sample:0",
+    },
+    {
+        "src": "prof_thread_name.c",
+        "prof_conf": "prof:true,prof_active:false",
+    },
+    {
+        "src": "prof_sys_thread_name.c",
+        "prof_conf": "prof:true,prof_active:true,lg_prof_sample:0,prof_sys_thread_name:true",
+    },
     {"src": "psset.c"},
     {"src": "ql.c"},
     {"src": "qr.c"},
@@ -105,7 +170,10 @@ UNIT_TESTS = [
     {"src": "sec.c"},
     {"src": "seq.c"},
     {"src": "SFMT.c"},
-    {"src": "size_check.c"},
+    {
+        "src": "size_check.c",
+        "prof_conf": "prof:false",
+    },
     {"src": "size_classes.c"},
     {"src": "slab.c"},
     {"src": "smoothstep.c"},
@@ -118,7 +186,10 @@ UNIT_TESTS = [
         "conf": "tcache_max:1024",
     },
     {"src": "test_hooks.c"},
-    {"src": "thread_event.c"},
+    {
+        "src": "thread_event.c",
+        "prof_conf": "prof:true,lg_prof_sample:0",
+    },
     {"src": "ticker.c"},
     {"src": "tsd.c"},
     {"src": "uaf.c"},
@@ -166,7 +237,12 @@ transition_default_constraints(
     name = test["name"] if "name" in test else test["src"].removesuffix(".c").replace("/", "_"),
     srcs = [test["src"]],
     copts = COPTS,
-    env = {"JE_TEST_MALLOC_CONF": test.get("conf", "")},
+    env = select({
+        "//settings/flags:prof": {
+            "JE_TEST_MALLOC_CONF": test.get("conf", "") + test.get("prof_conf", ""),
+        },
+        "//conditions:default": {"JE_TEST_MALLOC_CONF": test.get("conf", "")},
+    }),
     linkstatic = True,
     local_defines = ["JEMALLOC_UNIT_TEST"],
     deps = [":testlib"],


### PR DESCRIPTION
This PR adds new flags to build with `prof` enabled and a dep on `libunwind`:

```
--@jemalloc//settings/flags:enable_prof
--@jemalloc//settings/flags:enable_prof_libunwind
--@jemalloc//settings/flags:enable_prof_libgcc
--@jemalloc//settings/flags:enable_prof_gcc
```

Also fixed running with `--incompatible_config_setting_private_default_visibility`, which the BCR uses by default.

cc @sallustfire