### PR TITLE
chore: Treate the prof=true backtrace method as an enum

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,11 +1,8 @@
 common:prof-libunwind --//settings/flags:enable_xmalloc
-common:prof-libunwind --//settings/flags:enable_prof
-common:prof-libunwind --//settings/flags:enable_prof_libunwind
+common:prof-libunwind --//settings/flags:enable_prof=libunwind
 
 common:prof-libgcc --//settings/flags:enable_xmalloc
-common:prof-libgcc --//settings/flags:enable_prof
-common:prof-libgcc --//settings/flags:enable_prof_libgcc
+common:prof-libgcc --//settings/flags:enable_prof=libgcc
 
 common:prof-gcc --//settings/flags:enable_xmalloc
-common:prof-gcc --//settings/flags:enable_prof
-common:prof-gcc --//settings/flags:enable_prof_gcc
+common:prof-gcc --//settings/flags:enable_prof=gcc

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -120,6 +120,9 @@ cc_library(
             "-lrt",
         ],
         "//conditions:default": [],
+    }) + select({
+        "//settings/flags:prof": ["-lm"],
+        "//conditions:default": [],
     }),
     local_defines = select({
         "//settings:jet": ["JEMALLOC_JET"],

--- a/settings/flags/BUILD.bazel
+++ b/settings/flags/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag", "string_flag", "string_setting")
 
 package(default_visibility = ["//:__subpackages__"])
@@ -198,50 +199,47 @@ config_setting(
     flag_values = {":enable_zone_allocator": "yes"},
 )
 
-# JEMALLOC_PROF
-bool_flag(
+# JEMALLOC_PROF Enable allocation profiling with specified backtracing implementation
+string_flag(
     name = "enable_prof",
-    build_setting_default = False,
+    build_setting_default = "no",
+    values = [
+        "gcc",
+        "libgcc",
+        "libunwind",
+        "no",
+    ],
     visibility = ["//visibility:public"],
 )
 
-config_setting(
+selects.config_setting_group(
     name = "prof",
-    flag_values = {":enable_prof": "True"},
-)
-
-# JEMALLOC_PROF_LIBUNWIND
-bool_flag(
-    name = "enable_prof_libunwind",
-    build_setting_default = False,
-    visibility = ["//visibility:public"],
+    match_any = [
+        ":prof_gcc",
+        ":prof_libgcc",
+        ":prof_libunwind",
+    ],
 )
 
 config_setting(
-    name = "prof_libunwind",
-    flag_values = {":enable_prof_libunwind": "True"},
-)
-
-# JEMALLOC_PROF_LIBGCC
-bool_flag(
-    name = "enable_prof_libgcc",
-    build_setting_default = False,
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "prof_libgcc",
-    flag_values = {":enable_prof_libgcc": "True"},
+    name = "no_prof",
+    flag_values = {":enable_prof": "no"},
 )
 
 # JEMALLOC_PROF_GCC
-bool_flag(
-    name = "enable_prof_gcc",
-    build_setting_default = False,
-    visibility = ["//visibility:public"],
-)
-
 config_setting(
     name = "prof_gcc",
-    flag_values = {":enable_prof_gcc": "True"},
+    flag_values = {":enable_prof": "gcc"},
+)
+
+# JEMALLOC_PROF_LIBUNWIND
+config_setting(
+    name = "prof_libunwind",
+    flag_values = {":enable_prof": "libunwind"},
+)
+
+# JEMALLOC_PROF_LIBGCC
+config_setting(
+    name = "prof_libgcc",
+    flag_values = {":enable_prof": "libgcc"},
 )

--- a/tools/cc.bzl
+++ b/tools/cc.bzl
@@ -47,4 +47,7 @@ COPTS = ["-D_REENTRANT"] + select({
     ],
     "@platforms//os:macos": ["-DPIC"],
     "//conditions:default": [],
+}) + select({
+    "//settings/flags:prof_gcc": ["-fno-omit-frame-pointer"],
+    "//conditions:default": [],
 })


### PR DESCRIPTION
When --enable-prof is set during configure, detection of a suitable backtrace method is performed stopping with the first supported solution. This can be augmented by explicitly enabling or disabling detection of specific methods. To better model this in a bazel context, the //settings/flags:enable_prof is extended to have enumerable values where the backtrace method can be explicitly declared.