### PR TITLE
chore: Bazel 9 select() compatibility (#5)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
+common --incompatible_resolve_select_keys_eagerly
+
 common:prof-libunwind --//settings/flags:enable_xmalloc
 common:prof-libunwind --//settings/flags:enable_prof=libunwind
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
-common --incompatible_resolve_select_keys_eagerly
+common:bazel8 --incompatible_resolve_select_keys_eagerly
+common:bazel9 --incompatible_resolve_select_keys_eagerly
 
 common:prof-libunwind --//settings/flags:enable_xmalloc
 common:prof-libunwind --//settings/flags:enable_prof=libunwind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         bazel_version: ["7.x", "8.x", "9.x"]
+        include:
+          - bazel_version: "8.x"
+            bazel_config: "--config=bazel8"
+          - bazel_version: "9.x"
+            bazel_config: "--config=bazel9"
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0
@@ -32,11 +37,11 @@ jobs:
       - name: Build
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
-        run: bazel build //...
+        run: bazel build //... ${{ matrix.bazel_config }}
       - name: Test
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
-        run: bazel test //...
+        run: bazel test //... ${{ matrix.bazel_config }}
 
   prof-libunwind:
     name: Prof libunwind (${{ matrix.os }}, Bazel ${{ matrix.bazel_version }})
@@ -46,6 +51,11 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
         bazel_version: ["7.x", "8.x", "9.x"]
+        include:
+          - bazel_version: "8.x"
+            bazel_config: "--config=bazel8"
+          - bazel_version: "9.x"
+            bazel_config: "--config=bazel9"
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0
@@ -55,11 +65,11 @@ jobs:
       - name: Build
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
-        run: bazel build //... --config=prof-libunwind
+        run: bazel build //... --config=prof-libunwind ${{ matrix.bazel_config }}
       - name: Test
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
-        run: bazel test //... --config=prof-libunwind
+        run: bazel test //... --config=prof-libunwind ${{ matrix.bazel_config }}
 
   prof-libgcc:
     name: Prof libgcc (${{ matrix.os }}, Bazel ${{ matrix.bazel_version }})
@@ -69,6 +79,11 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-14, macos-15]
         bazel_version: ["7.x", "8.x", "9.x"]
+        include:
+          - bazel_version: "8.x"
+            bazel_config: "--config=bazel8"
+          - bazel_version: "9.x"
+            bazel_config: "--config=bazel9"
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0
@@ -78,11 +93,11 @@ jobs:
       - name: Build
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
-        run: bazel build //... --config=prof-libgcc
+        run: bazel build //... --config=prof-libgcc ${{ matrix.bazel_config }}
       - name: Test
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
-        run: bazel test //... --config=prof-libgcc ${{ startsWith(matrix.os, 'macos') && '-- -//test/unit:prof_gdump' || '' }}
+        run: bazel test //... --config=prof-libgcc ${{ matrix.bazel_config }} ${{ startsWith(matrix.os, 'macos') && '-- -//test/unit:prof_gdump' || '' }}
 
   prof-gcc:
     name: Prof gcc (${{ matrix.os }}, Bazel ${{ matrix.bazel_version }})
@@ -92,6 +107,11 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-14, macos-15]
         bazel_version: ["7.x", "8.x", "9.x"]
+        include:
+          - bazel_version: "8.x"
+            bazel_config: "--config=bazel8"
+          - bazel_version: "9.x"
+            bazel_config: "--config=bazel9"
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0
@@ -101,11 +121,11 @@ jobs:
       - name: Build
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
-        run: bazel build //... --config=prof-gcc
+        run: bazel build //... --config=prof-gcc ${{ matrix.bazel_config }}
       - name: Test
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
-        run: bazel test //... --config=prof-gcc ${{ startsWith(matrix.os, 'macos') && '-- -//test/unit:prof_gdump' || '' }}
+        run: bazel test //... --config=prof-gcc ${{ matrix.bazel_config }} ${{ startsWith(matrix.os, 'macos') && '-- -//test/unit:prof_gdump' || '' }}
 
   examples:
     name: Examples (${{ matrix.os }}, Bazel ${{ matrix.bazel_version }})
@@ -115,6 +135,11 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         bazel_version: ["7.x", "8.x", "9.x"]
+        include:
+          - bazel_version: "8.x"
+            bazel_config: "--config=bazel8"
+          - bazel_version: "9.x"
+            bazel_config: "--config=bazel9"
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0
@@ -125,9 +150,9 @@ jobs:
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
         working-directory: examples
-        run: bazel build //...
+        run: bazel build //... ${{ matrix.bazel_config }}
       - name: Test
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
         working-directory: examples
-        run: bazel test //...
+        run: bazel test //... ${{ matrix.bazel_config }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,12 +1,12 @@
 module(
     name = "jemalloc",
-    version = "5.3.0-bcr.alpha.5",
+    version = "5.3.0-bcr.alpha.6",
     bazel_compatibility = [">=7.4.0"],  # need support for "overlay" directory and cxxopts in cc_binary
     compatibility_level = 5,
 )
 
 bazel_dep(name = "bazel_lib", version = "3.2.2")
-bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "libunwind", version = "1.8.3")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_cc", version = "0.2.4")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "jemalloc",
-    version = "5.3.0-bcr.alpha.6",
+    version = "5.3.0-bcr.alpha.5",
     bazel_compatibility = [">=7.4.0"],  # need support for "overlay" directory and cxxopts in cc_binary
     compatibility_level = 5,
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -36,7 +36,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/source.json": "34a3c8bcf233b835eb74be9d628899bb32999d3e0eadef1947a0a562a2b16ffb",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
@@ -47,8 +48,8 @@
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
-    "https://bcr.bazel.build/modules/libunwind/1.8.1/MODULE.bazel": "d9b947b15135786aed51671c22872a93e2637c74caa20e94f2061fd3b1efd6c3",
-    "https://bcr.bazel.build/modules/libunwind/1.8.1/source.json": "2b4e58e2fa6ed7204862ab1a4e5978e4107340884c3217596ff7910b8dfae919",
+    "https://bcr.bazel.build/modules/libunwind/1.8.3/MODULE.bazel": "ecc153c0d2f661fd730243439b2ca454968f21b7e73ff5f1ff1545b70e87a8a7",
+    "https://bcr.bazel.build/modules/libunwind/1.8.3/source.json": "8bba6459bed0b337c50f554292d724e2736edf906379556fa56a8a57d5a5299d",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
@@ -138,14 +139,80 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
     "https://bcr.bazel.build/modules/stardoc/0.7.1/source.json": "b6500ffcd7b48cd72c29bb67bcac781e12701cc0d6d55d266a652583cfcdab01",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
-    "https://bcr.bazel.build/modules/xz/5.4.5.bcr.5/MODULE.bazel": "b93d7035ac14c900dfdf7624e42cfcbfc34415aa8d3c83a6f225867c48d28dad",
-    "https://bcr.bazel.build/modules/xz/5.4.5.bcr.5/source.json": "30c4e5c856087a60d92e2522eafd316c0661671f4478ca94c6b7bd877010210a",
+    "https://bcr.bazel.build/modules/xz/5.4.5.bcr.8/MODULE.bazel": "e48a69bd54053c2ec5fffc2a29fb70122afd3e83ab6c07068f63bc6553fa57cc",
+    "https://bcr.bazel.build/modules/xz/5.4.5.bcr.8/source.json": "bd7e928ccd63505b44f4784f7bbf12cc11f9ff23bf3ca12ff2c91cd74846099e",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.8/MODULE.bazel": "772c674bb78a0342b8caf32ab5c25085c493ca4ff08398208dcbe4375fe9f776",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.8/source.json": "cf377d76800dfc3d3b71e9dd4a8c53a62837cbce37cc4f25e6207b15fc1e8f2b",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
-  "moduleExtensions": {},
+  "moduleExtensions": {
+    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "nvW/NrBXlAmiQw99EMGKkLaD2KbNp2mQDlxdfpr+0Ls=",
+        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
+            }
+          },
+          "com_github_pinterest_ktlint": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
+              ],
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    }
+  },
   "facts": {}
 }

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -1,0 +1,2 @@
+common:bazel8 --incompatible_resolve_select_keys_eagerly
+common:bazel9 --incompatible_resolve_select_keys_eagerly

--- a/include/jemalloc/BUILD.bazel
+++ b/include/jemalloc/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
@@ -24,11 +23,13 @@ configure_header(
         define_macro_if("JEMALLOC_OVERRIDE_VALLOC", "//settings/platform:has_valloc") |
         define_macro_with("JEMALLOC_USABLE_SIZE_CONST", "$(JEMALLOC_USABLE_SIZE_CONST)") |
         define_macro_if("JEMALLOC_USE_CXX_THROW", "@platforms//os:linux") |
-        selects.with_or(
+        select(
             {
                 "//settings/compiler:msvc_compatible": define_macro_with("LG_SIZEOF_PTR", "LG_SIZEOF_PTR_WIN"),
-                ("@platforms//cpu:aarch32", "@platforms//cpu:x86_32"): define_macro_with("LG_SIZEOF_PTR", "2"),
-                ("@platforms//cpu:aarch64", "@platforms//cpu:x86_64"): define_macro_with("LG_SIZEOF_PTR", "3"),
+                "@platforms//cpu:aarch32": define_macro_with("LG_SIZEOF_PTR", "2"),
+                "@platforms//cpu:x86_32": define_macro_with("LG_SIZEOF_PTR", "2"),
+                "@platforms//cpu:aarch64": define_macro_with("LG_SIZEOF_PTR", "3"),
+                "@platforms//cpu:x86_64": define_macro_with("LG_SIZEOF_PTR", "3"),
             },
             no_match_error = "Cannot determine LG_SIZEOF_PTR value, missing support for platform.",
         ),

--- a/tools/cc.bzl
+++ b/tools/cc.bzl
@@ -1,7 +1,5 @@
 "Project specific configuration of rules_cc"
 
-load("@bazel_skylib//lib:selects.bzl", "selects")
-
 _COPTS_GCC_COMPATIBLE = [
     "-Wall",
     "-Wextra",
@@ -32,12 +30,17 @@ COPTS = ["-D_REENTRANT"] + select({
     "@rules_cc//cc/compiler:msvc-cl": _COPTS_MSVC_COMPATIBLE,
     "@rules_cc//cc/compiler:clang-cl": _COPTS_MSVC_COMPATIBLE,
     "//conditions:default": [],
-}) + selects.with_or({
-    ("@platforms//os:windows", "//settings/platform:darwin"): [],
+}) + select({
+    "@platforms//os:windows": [],
+    "//settings/platform:darwin": [],
     "//settings/compiler:gcc_compatible": ["-fvisibility=hidden"],
     "//conditions:default": [],
-}) + selects.with_or({
-    ("@platforms//os:android", "@platforms//os:linux"): [
+}) + select({
+    "@platforms//os:android": [
+        "-DPIC",
+        "-D_GNU_SOURCE",
+    ],
+    "@platforms//os:linux": [
         "-DPIC",
         "-D_GNU_SOURCE",
     ],


### PR DESCRIPTION
Replace selects.with_or() with expanded select() calls so that repo-relative labels are resolved in the correct repository context when --incompatible_resolve_select_keys_eagerly is enabled, in preparation for this becoming the default in a future Bazel release.

Also bumps bazel_skylib to 1.8.2 and removes the deprecated compatibility_level attribute from MODULE.bazel.