### PR TITLE
chore: add CI publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,133 @@
+name: CI
+
+on:
+  push:
+    branches: [bcr-5.3.0]
+  pull_request:
+    branches: [bcr-5.3.0]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }}, Bazel ${{ matrix.bazel_version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        bazel_version: ["7.x", "8.x", "9.x", "latest"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.14.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
+      - name: Build
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        run: bazel build //...
+      - name: Test
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        run: bazel test //...
+
+  prof-libunwind:
+    name: Prof libunwind (${{ matrix.os }}, Bazel ${{ matrix.bazel_version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+        bazel_version: ["7.x", "8.x", "9.x", "latest"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.14.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
+      - name: Build
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        run: bazel build //... --config=prof-libunwind
+      - name: Test
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        run: bazel test //... --config=prof-libunwind
+
+  prof-libgcc:
+    name: Prof libgcc (${{ matrix.os }}, Bazel ${{ matrix.bazel_version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        bazel_version: ["7.x", "8.x", "9.x", "latest"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.14.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
+      - name: Build
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        run: bazel build //... --config=prof-libgcc
+      - name: Test
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        run: bazel test //... --config=prof-libgcc ${{ startsWith(matrix.os, 'macos') && '-- -//test/unit:prof_gdump' || '' }}
+
+  prof-gcc:
+    name: Prof gcc (${{ matrix.os }}, Bazel ${{ matrix.bazel_version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        bazel_version: ["7.x", "8.x", "9.x", "latest"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.14.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
+      - name: Build
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        run: bazel build //... --config=prof-gcc
+      - name: Test
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        run: bazel test //... --config=prof-gcc ${{ startsWith(matrix.os, 'macos') && '-- -//test/unit:prof_gdump' || '' }}
+
+  examples:
+    name: Examples (${{ matrix.os }}, Bazel ${{ matrix.bazel_version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        bazel_version: ["7.x", "8.x", "9.x", "latest"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.14.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
+      - name: Build
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        working-directory: examples
+        run: bazel build //...
+      - name: Test
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        working-directory: examples
+        run: bazel test //...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
-        bazel_version: ["7.x", "8.x", "9.x", "latest"]
+        bazel_version: ["7.x", "8.x", "9.x"]
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        bazel_version: ["7.x", "8.x", "9.x", "latest"]
+        bazel_version: ["7.x", "8.x", "9.x"]
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-14, macos-15]
-        bazel_version: ["7.x", "8.x", "9.x", "latest"]
+        bazel_version: ["7.x", "8.x", "9.x"]
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-14, macos-15]
-        bazel_version: ["7.x", "8.x", "9.x", "latest"]
+        bazel_version: ["7.x", "8.x", "9.x"]
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0
@@ -114,7 +114,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
-        bazel_version: ["7.x", "8.x", "9.x", "latest"]
+        bazel_version: ["7.x", "8.x", "9.x"]
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         bazel_version: ["7.x", "8.x", "9.x", "latest"]
     steps:
       - uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-24.04, macos-14, macos-15]
         bazel_version: ["7.x", "8.x", "9.x", "latest"]
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-24.04, macos-14, macos-15]
         bazel_version: ["7.x", "8.x", "9.x", "latest"]
     steps:
       - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         bazel_version: ["7.x", "8.x", "9.x", "latest"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-24.04, macos-13, macos-14]
         bazel_version: ["7.x", "8.x", "9.x", "latest"]
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-24.04, macos-13, macos-14]
         bazel_version: ["7.x", "8.x", "9.x", "latest"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to BCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Git tag to publish (e.g. 5.3.0-bcr.1)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v2
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      registry_fork: sallustfire/bazel-central-registry
+      draft: true
+      attest: false
+    permissions:
+      contents: read
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Add GitHub Actions CI that validates the Bazel build across platforms and configurations on every PR and push

## Context

The fork currently has no CI — build breakages are only caught manually or when submitting to the BCR. This adds a first line of defense that mirrors the BCR presubmit matrix, catching issues before a release is cut.

## CI matrix

| Job | BCR Presubmit Task | Platforms |
|---|---|---|
| `build` | `verify_jemalloc` | all 4 |
| `prof-libunwind` | `verify_jemalloc_with_prof_libunwind` | Linux only |
| `prof-libgcc` | `verify_jemalloc_with_prof_libgcc` | all 4 (excludes `prof_gdump` on macOS) |
| `prof-gcc` | `verify_jemalloc_with_prof_gcc` | all 4 (excludes `prof_gdump` on macOS) |
| `examples` | `bcr_test_module` | all 4 |

Each job runs across Bazel 7.x, 8.x, 9.x, and latest on ubuntu-22.04, ubuntu-24.04, macos-13, and macos-14.

## Next steps

`.bcr/` template files will follow in a separate PR.