### PR TITLE
chore: Add BCR template files for publish-to-bcr

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://jemalloc.net/",
+    "maintainers": [
+        {
+            "email": "sallustfire@gmail.com",
+            "github": "sallustfire",
+            "github_user_id": 565618,
+            "name": "Connor McEntee"
+        }
+    ],
+    "repository": [
+        "github:jemalloc/jemalloc"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,37 @@
+matrix:
+  platform:
+    - fedora40
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+  bazel: ["7.x", "8.x", "9.x", "rolling"]
+tasks:
+  verify_jemalloc:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@jemalloc"
+
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform:
+      - fedora40
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - ubuntu2404
+      - macos
+      - macos_arm64
+    bazel: ["7.x", "8.x", "9.x", "rolling"]
+  tasks:
+    verify_examples:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."
+      test_targets:
+        - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz",
+    "strip_prefix": "{REPO}-{TAG}",
+    "integrity": ""
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v2
@@ -18,7 +21,5 @@ jobs:
       registry_fork: sallustfire/bazel-central-registry
       draft: true
       attest: false
-    permissions:
-      contents: read
     secrets:
       publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Migrates from the manual overlay model (`jemalloc_to_bcr.sh` + hand-crafted BCR PRs) to the colocated model where the fork's release tarballs contain source + Bazel files. This lets `publish-to-bcr` handle BCR submission out of the box.

- Add `.bcr/` template files enabling automated BCR publishing via `publish-to-bcr`
- Simplify BCR presubmit to e2e consumer validation only

## Design decisions

**Presubmit scoped to e2e only.** The previous BCR presubmit ran the full internal test suite with 4 prof configurations. The fork's CI now owns that responsibility. The BCR presubmit is simplified to: (1) verify the module builds across
 all platforms, and (2) run the `examples/` consumer integration test. This matches the BCR's purpose — validating "does this module work as a dependency?" not "is the module internally correct?"

**No patches.** The overlay model used `skipped-tests-exit-0.patch` to fix test exit codes. The colocated model doesn't need it — the fix is already in the fork's source tree at `test/src/test.c:184`.
