### PR TITLE
chore: bump version to 5.3.0-bcr.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "jemalloc",
-    version = "5.3.0-bcr.alpha.5",
+    version = "5.3.0-bcr.1",
     bazel_compatibility = [">=7.4.0"],  # need support for "overlay" directory and cxxopts in cc_binary
     compatibility_level = 5,
 )


### PR DESCRIPTION
Bump MODULE.bazel version to `5.3.0-bcr.1` — first release under the colocated model with automated BCR publishing via publish-to-bcr.
                                                                                                                                                                                                                                              